### PR TITLE
mod 2 eslint rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,7 +9,13 @@
     "global-require": 0,
     "no-param-reassign": 0,
     "new-cap": 0,
-    "no-eval": 0
+    "no-eval": 0,
+    "semi": 0,
+    "space-before-function-paren": ["error", {
+      "anonymous": "always",
+      "named": "always",
+      "asyncArrow": "ignore"
+    }]
   },
   "settings": {
     "import/resolver": {


### PR DESCRIPTION
增加两条规则：
1. 去掉行末的 semicolon ;
2. 函数定义时候括号前加上空格
 ```
function () {...}
function MyFunc () {...}
```
