### PR TITLE
Close tabs with middle click

### DIFF
--- a/app/commons/Tab/TabLabel.jsx
+++ b/app/commons/Tab/TabLabel.jsx
@@ -8,6 +8,16 @@ import { dispatch } from '../../store'
 
 let TabLabel = observer(({tab, removeTab, activateTab, openContextMenu}) => {
   const tabLabelId = `tab_label_${tab.id}`
+  let middleClickClose;
+  let isIE = !!navigator.userAgent.match(/Trident/g) || !!navigator.userAgent.match(/MSIE/g);
+  if (isIE) {
+    middleClickClose = <button className="tabMiddleClickButton"
+      onMouseUp={e => { if (e.button == 1) { e.stopPropagation; removeTab(tab.id) }}}></button>
+  } else {
+    middleClickClose = <a className="tabMiddleClickAnchor"
+      href="#"
+      onMouseUp={e => { if (e.button == 1) { e.stopPropagation; removeTab(tab.id) }}}></a>
+  }
   return (
     <li className={cx('tab-label', {
       active: tab.isActive,
@@ -23,6 +33,7 @@ let TabLabel = observer(({tab, removeTab, activateTab, openContextMenu}) => {
       }}
       onContextMenu={e => openContextMenu(e, tab)}
     >
+      {middleClickClose}
       {dnd.target.id === tabLabelId ? <div className='tab-label-insert-pos'></div>: null}
       {tab.icon ? <div className={tab.icon}></div>: null}
       <div className='title'>{tab.title}</div>

--- a/app/styles/main.styl
+++ b/app/styles/main.styl
@@ -36,6 +36,23 @@
   align-items: stretch;
 }
 
+.tabMiddleClickButton {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  opacity: 0;
+}
+
+.tabMiddleClickAnchor {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+}
+
 .utilities-container {
   isolation: isolate;
   z-index: z(utilities-container);


### PR DESCRIPTION
Now tabs can be closed with middle-click like most other IDEs and all browsers. This was tested in Chrome, Firefox, Edge, and IE 11. IE required the use of a button instead of an anchor; it would open a new tab in the browser, even when `e.preventDefault()` was called on `OnClick` and `OnMouseDown`.
For all other browsers it adds an anchor next to the tab content and absolutely positions it and fills the tab with it. The anchor listens for a middle click event and closes the tab when it hears it. Just adding the handler on the `<li>` worked, but caused the browser to show its 'free scroll' icon, which is annoying.