### PR TITLE
升级 monaco 语言服务客户端，修复部分跳转 bug

### DIFF
--- a/app/commands/commandBindings/file.js
+++ b/app/commands/commandBindings/file.js
@@ -170,10 +170,17 @@ export function openFile (obj, callback) {
         existingTab.editor.gitBlame = editor.gitBlame
       }
       if (editor.selection) {
-        const { startLineNumber } = editor.selection
-        existingTab.editorInfo.monacoEditor.setSelection(editor.selection)
-        existingTab.editorInfo.monacoEditor.focus()
-        existingTab.editorInfo.monacoEditor.revealLineInCenter(startLineNumber, 1)
+        const { startLineNumber, startColumn } = editor.selection
+
+        const pos = {
+          lineNumber: startLineNumber,
+          column: startColumn,
+        }
+  
+        setTimeout(() => {
+          existingTab.editorInfo.monacoEditor.setPosition(pos)
+          existingTab.editorInfo.monacoEditor.revealPositionInCenter(pos, 1)
+        }, 0)
       }
 
       if (editor.debug) {

--- a/app/components/MonacoEditor/Editors/createHelper.js
+++ b/app/components/MonacoEditor/Editors/createHelper.js
@@ -1,11 +1,11 @@
-import { createConnection } from 'vscode-base-languageclient/lib/connection'
-import { BaseLanguageClient } from 'vscode-base-languageclient/lib/base'
 import {
   MonacoToProtocolConverter,
   ProtocolToMonacoConverter,
   MonacoCommands,
   MonacoLanguages,
   MonacoWorkspace,
+  MonacoLanguageClient,
+  createConnection
 } from 'monaco-languageclient'
 import io from 'socket.io-client'
 import { lowerCase } from 'lodash'
@@ -15,6 +15,55 @@ import { documentSelectors } from '../utils/languages'
 import initializationOptions from '../utils/initializationOptions'
 import synchronize from '../utils/synchronize'
 
+class ConsoleWindow {
+  constructor () {
+    this.channels = new Map()
+  }
+
+  showMessage (type, message) {
+    const actions = []
+    for (let _i = 2; _i < arguments.length; _i++) {
+      actions[_i - 2] = arguments[_i]
+    }
+    if (type === services_1.MessageType.Error) {
+      // no-op
+    }
+    if (type === services_1.MessageType.Warning) {
+      // no-op
+    }
+    if (type === services_1.MessageType.Info) {
+      // no-op
+    }
+    if (type === services_1.MessageType.Log) {
+      // no-op
+    }
+    return Promise.resolve(undefined)
+  }
+
+  createOutputChannel = (name) => {
+    const existing = this.channels.get(name)
+    if (existing) {
+      return existing
+    }
+    const channel = {
+      append (value) {
+        // no-op
+      },
+      appendLine (line) {
+        // no-op
+      },
+      show () {
+        // no-op
+      },
+      dispose () {
+        // no-op
+      }
+    }
+    this.channels.set(name, channel)
+    return channel
+  }
+}
+
 export function createMonacoServices (editor, options) {
   const m2p = new MonacoToProtocolConverter()
   const p2m = new ProtocolToMonacoConverter()
@@ -22,20 +71,20 @@ export function createMonacoServices (editor, options) {
     commands: new MonacoCommands(editor),
     languages: new MonacoLanguages(p2m, m2p),
     workspace: new MonacoWorkspace(p2m, m2p, options.rootUri),
-    window: null
+    window: new ConsoleWindow()
   }
 }
 
 export function createLanguageClient (services, connection) {
   const currentDocumentSelector = documentSelectors.find(v => v.lang === config.mainLanguage)
   const initializationOption = initializationOptions[config.mainLanguage]
-  return new BaseLanguageClient({
+  return new MonacoLanguageClient({
     name: `[${config.mainLanguage}-langServer]`,
     clientOptions: {
       commands: undefined,
       documentSelector: currentDocumentSelector.selectors,
       synchronize: {
-        configurationSection: synchronize[config.mainLanguage],
+        configurationSection: synchronize[config.mainLanguage]
       },
       initializationOptions: {
         ...initializationOption,
@@ -44,19 +93,22 @@ export function createLanguageClient (services, connection) {
       initializationFailedHandler: (err) => {
         const detail = err instanceof Error ? err.message : ''
       },
-      diagnosticCollectionName: lowerCase(config.mainLanguage),
+      diagnosticCollectionName: lowerCase(config.mainLanguage)
     },
-    services,
+    // services,
     connectionProvider: {
       get: (errorHandler, closeHandler) =>
-        Promise.resolve(createConnection(connection, errorHandler, closeHandler)),
-    },
+        Promise.resolve(createConnection(connection, errorHandler, closeHandler))
+    }
   })
 }
 
 const wsUrl = config.wsURL
 const firstSlashIdx = wsUrl.indexOf('/', 8)
-const [host, serverpath] = firstSlashIdx === -1 ? [wsUrl, ''] : [wsUrl.substring(0, firstSlashIdx), wsUrl.substring(firstSlashIdx)]
+const [host, serverpath] =
+  firstSlashIdx === -1
+    ? [wsUrl, '']
+    : [wsUrl.substring(0, firstSlashIdx), wsUrl.substring(firstSlashIdx)]
 
 export function createWebSocket () {
   const socketOptions = {
@@ -70,5 +122,8 @@ export function createWebSocket () {
       language: lowerCase(config.mainLanguage)
     }
   }
-  return io.connect(host, socketOptions)
+  return io.connect(
+    host,
+    socketOptions
+  )
 }

--- a/app/components/MonacoEditor/LanguageClientState.js
+++ b/app/components/MonacoEditor/LanguageClientState.js
@@ -114,6 +114,12 @@ export class LanguageClient {
   start = () => {
     listen({
       webSocket: this.ioToWebSocket,
+      logger: Object.freeze({
+        error: () => {},
+        warn: () => {},
+        info: () => {},
+        log: () => {}
+      }),
       onConnection: (connection) => {
         this.client = createLanguageClient(
           this.services,

--- a/app/components/MonacoEditor/MonacoReact/BaseEditor.jsx
+++ b/app/components/MonacoEditor/MonacoReact/BaseEditor.jsx
@@ -118,7 +118,15 @@ class MonacoEditor extends React.PureComponent {
         monacoEditor.setModel(model)
 
         if (this.editor.selection) {
-          monacoEditor.setSelection(this.editor.selection)
+          const pos = {
+            lineNumber: this.editor.selection.startLineNumber,
+            column: this.editor.selection.startColumn,
+          }
+    
+          setTimeout(() => {
+            monacoEditor.setPosition(pos)
+            monacoEditor.revealPositionInCenter(pos, 1)
+          }, 0)
         }
         const { client, openeduri } = languageClient
         if (client && client.state === 3 && this.props.active && this.didmount) {

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "mobx-react": "^4.1.5",
     "moment": "^2.18.1",
     "monaco-editor": "0.14.1",
-    "monaco-languageclient": "^0.6.3",
+    "monaco-languageclient": "^0.9.0",
     "mousetrap": "^1.6.1",
     "octicons": "4.4.0",
     "prop-types": "^15.5.10",

--- a/webpack_configs/common.config.js
+++ b/webpack_configs/common.config.js
@@ -73,7 +73,8 @@ module.exports = function(options = {}) {
       extensions: ['*', '.js', '.jsx'],
       modules: ['node_modules', path.join(PROJECT_ROOT, 'app')],
       alias: {
-        static: path.join(PROJECT_ROOT, 'static')
+        static: path.join(PROJECT_ROOT, 'static'),
+        'vscode': require.resolve('monaco-languageclient/lib/vscode-compatibility')
       }
     },
     resolveLoader: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6414,10 +6414,6 @@ moment@^2.18.1:
   version "2.18.1"
   resolved "http://registry.npm.taobao.org/moment/download/moment-2.18.1.tgz#c36193dd3ce1c2eed2adb7c802dbbc77a81b1c0f"
 
-monaco-editor-core@^0.12.0:
-  version "0.12.0"
-  resolved "http://registry.npm.taobao.org/monaco-editor-core/download/monaco-editor-core-0.12.0.tgz#185c4233907582b78472fe30bad13af7ad6e8d8e"
-
 monaco-editor-webpack-plugin@^1.3.0:
   version "1.3.0"
   resolved "http://registry.npm.taobao.org/monaco-editor-webpack-plugin/download/monaco-editor-webpack-plugin-1.3.0.tgz#3a6c1ede01321f24cc1f7b3de8b1e355667840f6"
@@ -6426,14 +6422,14 @@ monaco-editor@0.14.1:
   version "0.14.1"
   resolved "http://registry.npm.taobao.org/monaco-editor/download/monaco-editor-0.14.1.tgz#4d3f310166c9916e238346d0ebedf21de7d9c8f2"
 
-monaco-languageclient@^0.6.3:
-  version "0.6.3"
-  resolved "http://registry.npm.taobao.org/monaco-languageclient/download/monaco-languageclient-0.6.3.tgz#ab652a9ac6803dc93414f601e32421b1bef20aac"
+monaco-languageclient@^0.9.0:
+  version "0.9.0"
+  resolved "http://registry.npm.taobao.org/monaco-languageclient/download/monaco-languageclient-0.9.0.tgz#4b65684e277edab07625e76eb3d3d93e8f2130fa"
   dependencies:
     glob-to-regexp "^0.3.0"
-    monaco-editor-core "^0.12.0"
-    vscode-base-languageclient "^0.0.1-alpha.5"
-    vscode-languageserver-types "^3.7.0"
+    vscode-base-languageclient "4.4.0"
+    vscode-jsonrpc "^3.6.2"
+    vscode-uri "^1.0.5"
 
 mousetrap@^1.6.1:
   version "1.6.1"
@@ -9754,6 +9750,12 @@ vm-browserify@0.0.4:
   dependencies:
     indexof "0.0.1"
 
+vscode-base-languageclient@4.4.0:
+  version "4.4.0"
+  resolved "http://registry.npm.taobao.org/vscode-base-languageclient/download/vscode-base-languageclient-4.4.0.tgz#07098fe42a986e8b65e47960de5ccf656aefe8d0"
+  dependencies:
+    vscode-languageserver-protocol "^3.10.0"
+
 vscode-base-languageclient@^0.0.1-alpha.5:
   version "0.0.1-alpha.5"
   resolved "http://registry.npm.taobao.org/vscode-base-languageclient/download/vscode-base-languageclient-0.0.1-alpha.5.tgz#2a908a7bc6fe7d60574c103f669c656354818e7e"
@@ -9766,9 +9768,20 @@ vscode-jsonrpc@^3.2.0, vscode-jsonrpc@^3.3.0, vscode-jsonrpc@^3.6.2:
   version "3.6.2"
   resolved "http://registry.npm.taobao.org/vscode-jsonrpc/download/vscode-jsonrpc-3.6.2.tgz#3b5eef691159a15556ecc500e9a8a0dd143470c8"
 
+vscode-jsonrpc@^4.0.0:
+  version "4.0.0"
+  resolved "http://registry.npm.taobao.org/vscode-jsonrpc/download/vscode-jsonrpc-4.0.0.tgz#a7bf74ef3254d0a0c272fab15c82128e378b3be9"
+
 "vscode-jsonrpc@https://github.com/SakuraAsh/vscode-jsonrpc-coding.git":
   version "3.6.2"
   resolved "https://github.com/SakuraAsh/vscode-jsonrpc-coding.git#f04672d0e167199ef46eba07777be00451b4296f"
+
+vscode-languageserver-protocol@^3.10.0:
+  version "3.13.0"
+  resolved "http://registry.npm.taobao.org/vscode-languageserver-protocol/download/vscode-languageserver-protocol-3.13.0.tgz#710d8e42119bb3affb1416e1e104bd6b4d503595"
+  dependencies:
+    vscode-jsonrpc "^4.0.0"
+    vscode-languageserver-types "3.13.0"
 
 vscode-languageserver-protocol@^3.8.1:
   version "3.8.1"
@@ -9777,7 +9790,11 @@ vscode-languageserver-protocol@^3.8.1:
     vscode-jsonrpc "^3.6.2"
     vscode-languageserver-types "^3.8.1"
 
-vscode-languageserver-types@^3.2.0, vscode-languageserver-types@^3.7.0:
+vscode-languageserver-types@3.13.0:
+  version "3.13.0"
+  resolved "http://registry.npm.taobao.org/vscode-languageserver-types/download/vscode-languageserver-types-3.13.0.tgz#b704b024cef059f7b326611c99b9c8753c0a18b4"
+
+vscode-languageserver-types@^3.2.0:
   version "3.7.1"
   resolved "http://registry.npm.taobao.org/vscode-languageserver-types/download/vscode-languageserver-types-3.7.1.tgz#4835d1c1811f91dd5c92e9446e5b29edd2216969"
 
@@ -9788,6 +9805,10 @@ vscode-languageserver-types@^3.8.1:
 vscode-uri@^1.0.0, vscode-uri@^1.0.3:
   version "1.0.3"
   resolved "http://registry.npm.taobao.org/vscode-uri/download/vscode-uri-1.0.3.tgz#631bdbf716dccab0e65291a8dc25c23232085a52"
+
+vscode-uri@^1.0.5:
+  version "1.0.6"
+  resolved "http://registry.npm.taobao.org/vscode-uri/download/vscode-uri-1.0.6.tgz#6b8f141b0bbc44ad7b07e94f82f168ac7608ad4d"
 
 vscode-ws-jsonrpc@^0.0.1-alpha.5:
   version "0.0.1-alpha.5"


### PR DESCRIPTION
* 升级 monaco-languageclient 版本为 0.9.0
* 修改语言服务客户端创建方式
* 修复新版本 monaco-editor API 变动导致的定义跳转bug
* 修改定义跳转到指定行的逻辑
* 修改 webpack 配置，添加 vscode 别名